### PR TITLE
Fix host faction check

### DIFF
--- a/Source/Soyuz/Core/ContextualExtensions_temp.cs
+++ b/Source/Soyuz/Core/ContextualExtensions_temp.cs
@@ -27,7 +27,7 @@ namespace Soyuz
                 Faction playerFaction = Faction.OfPlayer;
                 if (pawn.factionInt == playerFaction)
                     return false;
-                if (pawn.guest?.isPrisonerInt ?? false && pawn.guest?.hostFactionInt == playerFaction)
+                if ((pawn.guest?.isPrisonerInt ?? false) && pawn.guest?.hostFactionInt == playerFaction)
                     return false;
                 if (RocketPrefs.TimeDilationVisitors)
                 {


### PR DESCRIPTION
`&&` binds more strongly than `??` so the condition is actually:

`pawn.guest?.isPrisonerInt ?? (false && pawn.guest?.hostFactionInt == playerFaction)`

False && Anything is always false so the latter condition is never checked. Adding brackets fixes this